### PR TITLE
chore: bump version to 0.3.0 and add pull_logs_raw API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.0]
+
+### Added
+
+- **New Raw Data API**: Added `pull_logs_raw` for retrieving raw protobuf bytes
+  - `pull_logs_raw` - Pull decompressed raw protobuf bytes from a shard without deserialization
+  - Returns `bytes::Bytes` containing raw Protocol Buffer data
+  - Supports all the same parameters as `pull_logs`: `cursor`, `end_cursor`, `count`, `query`, `query_id`
+  - Useful for scenarios requiring direct protobuf data access or custom processing pipelines
+
 ## [0.2.0]
 
 ### Added

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aliyun-log-rust-sdk"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Aliyun Log Service"]
 homepage = "https://github.com/aliyun/aliyun-log-rust-sdk/tree/master/client"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -34,6 +34,8 @@ pub(crate) use crate::macros::*;
 
 mod pull_logs;
 pub use pull_logs::*;
+mod pull_logs_raw;
+pub use pull_logs_raw::*;
 mod put_logs;
 pub use put_logs::*;
 mod get_cursor;

--- a/client/src/client/consumer_group/get_consumer_group_checkpoint.rs
+++ b/client/src/client/consumer_group/get_consumer_group_checkpoint.rs
@@ -123,11 +123,7 @@ impl Request for GetConsumerGroupCheckpointRequest {
     }
 
     fn query_params(&self) -> Option<Vec<(String, String)>> {
-        if let Some(shard_id) = self.shard_id {
-            Some(vec![("shard".to_string(), shard_id.to_string())])
-        } else {
-            None
-        }
+        self.shard_id.map(|shard_id| vec![("shard".to_string(), shard_id.to_string())])
     }
 }
 

--- a/client/src/client/pull_logs_raw.rs
+++ b/client/src/client/pull_logs_raw.rs
@@ -1,0 +1,274 @@
+use super::*;
+use super::{BuildResult, HandleRef};
+use crate::compress::CompressType;
+use crate::request::Request;
+use crate::response::FromHttpResponse;
+use crate::utils::ValueGetter;
+use crate::ResponseResult;
+use getset::Getters;
+use http::header::{ACCEPT, ACCEPT_ENCODING};
+
+impl crate::client::Client {
+    /// Pull raw protobuf bytes from a shard of a logstore from the given cursor.
+    ///
+    /// This method is similar to [`pull_logs`](crate::client::Client::pull_logs),
+    /// but returns the decompressed raw protobuf bytes without deserializing them.
+    /// This is useful when you need to process the raw protobuf data directly
+    /// or pass it to another system for processing.
+    ///
+    /// # Arguments
+    ///
+    /// * `project` - The name of the project containing the logstore
+    /// * `logstore` - The name of the logstore to pull logs from
+    /// * `shard_id` - The ID of the shard to pull logs from
+    ///
+    /// # Examples
+    ///
+    /// ## Basic usage:
+    ///
+    /// ```
+    /// # async fn example(client: aliyun_log_rust_sdk::Client) -> Result<(), aliyun_log_rust_sdk::Error> {
+    /// use aliyun_log_rust_sdk::get_cursor_models::CursorPos;
+    /// let shard_id = 0;
+    ///
+    /// // First, get a cursor for a shard
+    /// let resp = client.get_cursor("my-project", "my-logstore", shard_id)
+    ///     .cursor_pos(CursorPos::Begin)
+    ///     .send().await?;
+    /// let cursor = resp.get_body().cursor();
+    ///
+    /// // Then, pull raw protobuf bytes using that cursor
+    /// let resp = client.pull_logs_raw("my-project", "my-logstore", shard_id)
+    ///     .cursor(cursor)
+    ///     .count(100)
+    ///     .send().await?;
+    ///
+    /// // Get the raw protobuf bytes
+    /// let raw_data = resp.get_body().data();
+    /// println!("Received {} bytes of raw protobuf data", raw_data.len());
+    ///
+    /// // Access metadata
+    /// let next_cursor = resp.get_body().next_cursor();
+    /// println!("Next cursor: {}", next_cursor);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## Advanced usage with cursor range:
+    ///
+    /// ```
+    /// # async fn example(client: aliyun_log_rust_sdk::Client) -> Result<(), aliyun_log_rust_sdk::Error> {
+    /// use aliyun_log_rust_sdk::get_cursor_models::CursorPos;
+    /// let shard_id = 0;
+    ///
+    /// // Get start and end cursors
+    /// let resp = client.get_cursor("my-project", "my-logstore", shard_id)
+    ///     .cursor_pos(CursorPos::UnixTimeStamp(1700000000))
+    ///     .send().await?;
+    /// let start_cursor = resp.get_body().cursor();
+    ///
+    /// let resp = client.get_cursor("my-project", "my-logstore", shard_id)
+    ///     .cursor_pos(CursorPos::UnixTimeStamp(1700001234))
+    ///     .send().await?;
+    /// let end_cursor = resp.get_body().cursor();
+    ///
+    /// // Pull raw bytes between cursors
+    /// let resp = client.pull_logs_raw("my-project", "my-logstore", shard_id)
+    ///     .cursor(start_cursor)
+    ///     .end_cursor(end_cursor)
+    ///     .count(1000)
+    ///     .send().await?;
+    ///
+    /// println!("Retrieved {} bytes", resp.get_body().data().len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn pull_logs_raw(
+        &self,
+        project: impl AsRef<str>,
+        logstore: impl AsRef<str>,
+        shard_id: i32,
+    ) -> PullLogsRawRequestBuilder {
+        PullLogsRawRequestBuilder {
+            project: project.as_ref().to_string(),
+            path: format!("/logstores/{}/shards/{}", logstore.as_ref(), shard_id),
+            handle: self.handle.clone(),
+            cursor: None,
+            end_cursor: None,
+            count: None,
+            query: None,
+            query_id: None,
+        }
+    }
+}
+
+pub struct PullLogsRawRequestBuilder {
+    project: String,
+    path: String,
+    handle: HandleRef,
+    cursor: Option<String>,
+    end_cursor: Option<String>,
+    count: Option<i32>,
+    query: Option<String>,
+    query_id: Option<String>,
+}
+
+impl PullLogsRawRequestBuilder {
+    #[must_use = "the result future must be awaited"]
+    pub fn send(self) -> ResponseResultBoxFuture<PullLogsRawResponse> {
+        Box::pin(async move {
+            let (handle, request) = self.build()?;
+            handle.send(request).await
+        })
+    }
+
+    /// Required, the cursor to start pulling logs from, inclusive.
+    pub fn cursor<T: Into<String>>(mut self, cursor: T) -> Self {
+        self.cursor = Some(cursor.into());
+        self
+    }
+
+    /// Optional, the cursor to end pulling logs, exclusive.
+    pub fn end_cursor<T: Into<String>>(mut self, end_cursor: T) -> Self {
+        self.end_cursor = Some(end_cursor.into());
+        self
+    }
+
+    /// Required, the maximum number of log groups to pull.
+    pub fn count(mut self, count: i32) -> Self {
+        self.count = Some(count);
+        self
+    }
+
+    /// Optional, the query to filter logs, using the spl syntax, e.g, "* | where name = 'Mike'".
+    pub fn query<T: Into<String>>(mut self, query: T) -> Self {
+        self.query = Some(query.into());
+        self
+    }
+
+    pub fn query_id<T: Into<String>>(mut self, query_id: T) -> Self {
+        self.query_id = Some(query_id.into());
+        self
+    }
+
+    fn build(self) -> BuildResult<PullLogsRawRequest> {
+        check_required!(("cursor", self.cursor), ("count", self.count));
+
+        Ok((
+            self.handle.clone(),
+            PullLogsRawRequest {
+                cursor: self.cursor.unwrap(),
+                end_cursor: self.end_cursor,
+                count: self.count.unwrap(),
+                query: self.query,
+                query_id: self.query_id,
+                project: self.project,
+                path: self.path,
+            },
+        ))
+    }
+}
+
+#[derive(Debug, Getters, Default)]
+pub struct PullLogsRawResponse {
+    #[getset(get = "pub")]
+    data: bytes::Bytes,
+    #[getset(get = "pub")]
+    next_cursor: String,
+    #[getset(get = "pub")]
+    log_group_count: i32,
+    #[getset(get = "pub")]
+    read_last_cursor: Option<String>,
+    #[getset(get = "pub")]
+    raw_size_before_query: Option<i32>,
+    #[getset(get = "pub")]
+    data_count_before_query: Option<i32>,
+    #[getset(get = "pub")]
+    result_lines: Option<i32>,
+    #[getset(get = "pub")]
+    lines_before_query: Option<i32>,
+    #[getset(get = "pub")]
+    failed_lines: Option<i32>,
+}
+
+impl PullLogsRawResponse {
+    pub fn into_data(self) -> bytes::Bytes {
+        self.data
+    }
+}
+
+impl FromHttpResponse for PullLogsRawResponse {
+    fn try_from(body: bytes::Bytes, http_headers: &http::HeaderMap) -> ResponseResult<Self> {
+        let log_group_count = http_headers.get_i32_or_default("x-log-count", 0);
+        let read_last_cursor = http_headers.get_str("x-log-read-last-cursor");
+        let raw_size_before_query = http_headers.get_i32("x-log-rawdatasize");
+        let data_count_before_query = http_headers.get_i32("x-log-rawdatacount");
+        let result_lines = http_headers.get_i32("x-log-resultlines");
+        let lines_before_query = http_headers.get_i32("x-log-rawdatalines");
+        let failed_lines = http_headers.get_i32("x-log-failedlines");
+        let next_cursor = http_headers.get_str_or_default("x-log-cursor", "");
+
+        Ok(PullLogsRawResponse {
+            data: body,
+            next_cursor,
+            log_group_count,
+            read_last_cursor,
+            data_count_before_query,
+            result_lines,
+            lines_before_query,
+            failed_lines,
+            raw_size_before_query,
+        })
+    }
+}
+
+struct PullLogsRawRequest {
+    project: String,
+    path: String,
+    cursor: String,
+    end_cursor: Option<String>,
+    count: i32,
+    query: Option<String>,
+    query_id: Option<String>,
+}
+
+impl Request for PullLogsRawRequest {
+    const HTTP_METHOD: http::Method = http::Method::GET;
+    type ResponseBody = PullLogsRawResponse;
+
+    fn project(&self) -> Option<&str> {
+        Some(&self.project)
+    }
+
+    fn path(&self) -> &str {
+        &self.path
+    }
+    fn headers(&self) -> http::HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, LOG_PROTOBUF);
+        headers.insert(
+            ACCEPT_ENCODING,
+            CompressType::Lz4
+                .to_string()
+                .parse()
+                .expect("fail to insert CompressType into headers"),
+        );
+        headers
+    }
+    fn query_params(&self) -> Option<Vec<(String, String)>> {
+        let mut params = Vec::new();
+        params.push(("type".to_string(), "logs".to_string()));
+        params.push(("cursor".to_string(), self.cursor.clone()));
+        params.push(("count".to_string(), self.count.to_string()));
+        if let Some(end_cursor) = &self.end_cursor {
+            params.push(("endCursor".to_string(), end_cursor.clone()));
+        }
+        if let Some(query) = &self.query {
+            params.push(("query".to_string(), query.clone()));
+        }
+        if let Some(query_id) = &self.query_id {
+            params.push(("queryId".to_string(), query_id.clone()));
+        }
+        Some(params)
+    }
+}

--- a/client/tests/pull_logs_raw.rs
+++ b/client/tests/pull_logs_raw.rs
@@ -1,0 +1,151 @@
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use crate::common::*;
+    use aliyun_log_rust_sdk::get_cursor_models::*;
+    use aliyun_log_rust_sdk::Client;
+    use aliyun_log_rust_sdk::*;
+    use lazy_static::lazy_static;
+
+    lazy_static! {
+        static ref TEST_CLIENT: Client = {
+            Client::from_config(
+                Config::builder()
+                    .access_key(&TEST_ENV.access_key_id, &TEST_ENV.access_key_secret)
+                    .endpoint(&TEST_ENV.endpoint)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+    }
+
+    fn init() {
+        let _ = env_logger::builder()
+            .is_test(true)
+            .filter_level(log::LevelFilter::Debug)
+            .try_init();
+    }
+
+    #[tokio::test]
+    async fn test_pull_logs_raw() {
+        init();
+        let project = &TEST_ENV.project;
+        let logstore = &TEST_ENV.logstore;
+
+        let resp = TEST_CLIENT
+            .list_shards(project, logstore)
+            .send()
+            .await
+            .unwrap();
+        let shards = resp.get_body().shards();
+        let shard_id = shards[0].shard_id();
+
+        let resp = TEST_CLIENT
+            .get_cursor(project, logstore, *shard_id)
+            .cursor_pos(CursorPos::Begin)
+            .send()
+            .await
+            .unwrap();
+        let cursor = resp.get_body().cursor();
+
+        let resp = TEST_CLIENT
+            .pull_logs_raw(project, logstore, *shard_id)
+            .cursor(cursor)
+            .count(1000)
+            .send()
+            .await
+            .unwrap();
+
+        let body = resp.get_body();
+        println!("Raw data size: {} bytes", body.data().len());
+        println!("Log group count: {}", body.log_group_count());
+        println!("Next cursor: {}", body.next_cursor());
+
+        assert!(!body.next_cursor().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_pull_logs_raw_with_query() {
+        init();
+        let project = &TEST_ENV.project;
+        let logstore = &TEST_ENV.logstore;
+
+        let resp = TEST_CLIENT
+            .list_shards(project, logstore)
+            .send()
+            .await
+            .unwrap();
+        let shards = resp.get_body().shards();
+        let shard_id = shards[0].shard_id();
+
+        let resp = TEST_CLIENT
+            .get_cursor(project, logstore, *shard_id)
+            .cursor_pos(CursorPos::Begin)
+            .send()
+            .await
+            .unwrap();
+        let cursor = resp.get_body().cursor();
+
+        let resp = TEST_CLIENT
+            .pull_logs_raw(project, logstore, *shard_id)
+            .cursor(cursor)
+            .count(1000)
+            .query("* | where 1 = 1")
+            .send()
+            .await
+            .unwrap();
+
+        let body = resp.get_body();
+        println!("Raw data size: {} bytes", body.data().len());
+        println!("Log group count: {}", body.log_group_count());
+
+        assert!(!body.next_cursor().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_pull_logs_raw_with_end_cursor() {
+        init();
+        let project = &TEST_ENV.project;
+        let logstore = &TEST_ENV.logstore;
+
+        let resp = TEST_CLIENT
+            .list_shards(project, logstore)
+            .send()
+            .await
+            .unwrap();
+        let shards = resp.get_body().shards();
+        let shard_id = shards[0].shard_id();
+
+        let resp = TEST_CLIENT
+            .get_cursor(project, logstore, *shard_id)
+            .cursor_pos(CursorPos::Begin)
+            .send()
+            .await
+            .unwrap();
+        let start_cursor = resp.get_body().cursor();
+
+        let resp = TEST_CLIENT
+            .get_cursor(project, logstore, *shard_id)
+            .cursor_pos(CursorPos::End)
+            .send()
+            .await
+            .unwrap();
+        let end_cursor = resp.get_body().cursor();
+
+        let resp = TEST_CLIENT
+            .pull_logs_raw(project, logstore, *shard_id)
+            .cursor(start_cursor)
+            .end_cursor(end_cursor)
+            .count(1000)
+            .send()
+            .await
+            .unwrap();
+
+        let body = resp.get_body();
+        println!("Raw data size: {} bytes", body.data().len());
+        println!("Log group count: {}", body.log_group_count());
+        println!("Next cursor: {}", body.next_cursor());
+    }
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,6 +53,7 @@ APIs for writing and querying logs from logstores.
 * `put_logs_raw <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.put_logs_raw>`_ - Write raw log data to a logstore with custom compression
 * `get_logs <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.get_logs>`_ - Query logs within a time range using query or SQL syntax
 * `pull_logs <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.pull_logs>`_ - Pull logs from a specific shard for consumption
+* `pull_logs_raw <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.pull_logs_raw>`_ - Pull decompressed raw protobuf bytes from a shard without deserialization
 * `get_cursor <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.get_cursor>`_ - Get a cursor position from a specific time or location
 
 Shard Management

--- a/docs/api_cn.rst
+++ b/docs/api_cn.rst
@@ -54,6 +54,7 @@ Logstore 管理
 * `put_logs_raw <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.put_logs_raw>`_ - 使用自定义压缩方式向日志库写入原始日志数据
 * `get_logs <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.get_logs>`_ - 从日志库查询某一时间范围内的日志，支持使用查询或 sql 等语法
 * `pull_logs <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.pull_logs>`_ - 从特定 shard 分片拉取日志以进行消费
+* `pull_logs_raw <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.pull_logs_raw>`_ - 从特定 shard 拉取解压后的原始 protobuf 字节数据，不进行反序列化
 * `get_cursor <https://docs.rs/aliyun-log-rust-sdk/latest/aliyun_log_rust_sdk/struct.Client.html#method.get_cursor>`_ - 获取从特定时间或位置的日志游标位置
 
 分片管理


### PR DESCRIPTION
- Updated version in Cargo.toml to 0.3.0.
- Introduced pull_logs_raw API for pulling raw protobuf bytes from logstore.
- Added tests for pull_logs_raw functionality.
- Refactored query_params method in GetConsumerGroupCheckpointRequest for conciseness.